### PR TITLE
test.py and setup.sh improvement

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,10 +5,10 @@ set -e
 # Install uv if not already installed
 if ! command -v uv &> /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
-fi
 
-# Add uv to path
-source $HOME/.local/bin/env
+    # Add uv to path
+    source $HOME/.local/bin/env
+fi
 
 # Create a new virtual environment
 uv venv

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,2 +1,3 @@
 requests
 websockets
+langchain-nvidia-ai-endpoints


### PR DESCRIPTION
- only add uv to path if fresh install in `setup.sh`
- ensure that each of the models in the `models.json` works with the set NVIDIA_API_KEY. This will catch out of credits, forbidden, etc. errors
- adds speaker name params to `test.py` and will randomly select names by default
- adds a name param to `test.py` that the output mp3 is named as to avoid overwriting the previous test generation