### PR TITLE
Update docker ps cell to have bash cell magic

### DIFF
--- a/launchable/PDFtoPodcast.ipynb
+++ b/launchable/PDFtoPodcast.ipynb
@@ -198,6 +198,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%bash\n",
+    "\n",
     "!docker ps --format \"table {{.ID}}\\t{{.Names}}\\t{{.Status}}\""
    ]
   },


### PR DESCRIPTION
Updating the docker ps cell to add bash cell magic so that it will output correctly when run inside the Jupyter notebook.

Old way resulted in output like below:
![image](https://github.com/user-attachments/assets/bb464fb7-8c74-4f41-885f-ffd0d05e94df)

New way with bash cell magic outputs like expected.
![image](https://github.com/user-attachments/assets/b4e429a2-40da-4bc0-9858-5eacbd3e5633)
