### PR TITLE
docs: clarify .env setup and troubleshoot ~/.local/bin/env errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,50 @@ IMPORTANT:  This will be used in the NVIDIA_API_KEY environment variable below.
 
 4. **Set environment variables**
 
+   Create a `.env` file in the **root directory of the repository** with your API keys:
+
    ```bash
-   #Create env file with required variables in /home/<username>/.local/bin/env  
+   # Create .env file in the repo root directory
    echo "ELEVENLABS_API_KEY=your_key" >> .env
    echo "NVIDIA_API_KEY=your_key" >> .env
    echo "MAX_CONCURRENT_REQUESTS=1" >> .env
    ```
-> **Note:** the ElevenLabs API key can handle concurrent requests. For local development, set MAX_CONCURRENT_REQUESTS=1 to avoid rate-limiting issues.
+
+   Or create it manually by adding these lines to a new `.env` file:
+   ```
+   ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
+   NVIDIA_API_KEY=your_nvidia_api_key_here
+   MAX_CONCURRENT_REQUESTS=1
+   ```
+
+> **Note:** The ElevenLabs API key can handle concurrent requests. For local development, set MAX_CONCURRENT_REQUESTS=1 to avoid rate-limiting issues.
+
+<details>
+<summary><strong>Troubleshooting: <code>~/.local/bin/env: No such file or Directory</code></strong></summary>
+
+This error only occurs on **first-time setup** when `uv` hasn't been installed before.
+
+**Important:** Don't confuse these two files:
+| File | Location | Purpose |
+|------|----------|---------|
+| `.env` | Repo root | Your API keys (what you created above) |
+| `env` | `~/.local/bin/env` | Shell script auto-created by `uv` installer |
+
+**To fix:**
+```bash
+# Install uv (creates ~/.local/bin/env automatically)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Add uv to your PATH
+source ~/.local/bin/env
+
+# Now run make uv
+make uv
+```
+
+**Alternative:** If `uv` is already installed via Homebrew or pipx, just ensure it's in your PATH.
+
+</details>
 
 5. **Install dependencies**
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ IMPORTANT:  This will be used in the NVIDIA_API_KEY environment variable below.
 
    ```bash
    # Create .env file in the repo root directory
-   echo "ELEVENLABS_API_KEY=your_key" >> .env
-   echo "NVIDIA_API_KEY=your_key" >> .env
-   echo "MAX_CONCURRENT_REQUESTS=1" >> .env
+   cat > .env << 'EOF'
+   ELEVENLABS_API_KEY=your_key
+   NVIDIA_API_KEY=your_key
+   MAX_CONCURRENT_REQUESTS=1
+   EOF
    ```
 
    Or create it manually by adding these lines to a new `.env` file:
@@ -109,7 +111,7 @@ IMPORTANT:  This will be used in the NVIDIA_API_KEY environment variable below.
 > **Note:** The ElevenLabs API key can handle concurrent requests. For local development, set MAX_CONCURRENT_REQUESTS=1 to avoid rate-limiting issues.
 
 <details>
-<summary><strong>Troubleshooting: <code>~/.local/bin/env: No such file or Directory</code></strong></summary>
+<summary><strong>Troubleshooting: <code>~/.local/bin/env: No such file or directory</code></strong></summary>
 
 This error only occurs on **first-time setup** when `uv` hasn't been installed before.
 

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,10 @@ set -e
 # Install uv if not already installed
 if ! command -v uv &> /dev/null; then
     echo "Installing uv package manager..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    uv_install_script="$(mktemp)"
+    curl -LsSf https://astral.sh/uv/install.sh -o "$uv_install_script"
+    sh "$uv_install_script"
+    rm -f "$uv_install_script"
 
     # Add uv to path
     # The uv installer creates this env file to add uv to PATH
@@ -22,7 +25,7 @@ if ! command -v uv &> /dev/null; then
     # Verify uv is now available
     if ! command -v uv &> /dev/null; then
         echo "Error: uv installation succeeded but uv is not in PATH."
-        echo "Please add ~/.local/bin to your PATH and try again."
+        echo "Please ensure the directory containing the 'uv' binary is on your PATH (commonly ~/.local/bin or ~/.cargo/bin), then try again."
         exit 1
     fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -4,10 +4,27 @@ set -e
 
 # Install uv if not already installed
 if ! command -v uv &> /dev/null; then
+    echo "Installing uv package manager..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
 
     # Add uv to path
-    source $HOME/.local/bin/env
+    # The uv installer creates this env file to add uv to PATH
+    if [ -f "$HOME/.local/bin/env" ]; then
+        source "$HOME/.local/bin/env"
+    elif [ -f "$HOME/.cargo/env" ]; then
+        # Fallback: some versions install to .cargo/env
+        source "$HOME/.cargo/env"
+    else
+        # Manual fallback: add common uv install locations to PATH
+        export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+    fi
+    
+    # Verify uv is now available
+    if ! command -v uv &> /dev/null; then
+        echo "Error: uv installation succeeded but uv is not in PATH."
+        echo "Please add ~/.local/bin to your PATH and try again."
+        exit 1
+    fi
 fi
 
 # Create a new virtual environment


### PR DESCRIPTION
## Description
Clarifies the `.env` file setup instructions and adds troubleshooting for the `~/.local/bin/env` error that confuses first-time users.

## Changes
- Added clear instructions that `.env` goes in repo root only
- Added collapsible troubleshooting section explaining the `~/.local/bin/env` error
- Added table clarifying the difference between `.env` (API keys) vs `env` (uv PATH script)
- Made `setup.sh` more robust with fallbacks for different uv install locations

## Related Issue
Fixes #12

## Testing
- Tested `make uv` successfully after following the updated instructions