### PR TITLE
Fix validation errors and runtime exceptions in podcast generation workflow

### DIFF
--- a/frontend/__main__.py
+++ b/frontend/__main__.py
@@ -233,7 +233,10 @@ with gr.Blocks(css=css, js=js_func) as demo:
         if target is None or len(target) == 0:
             gr.Warning("Target PDF upload not detected. Please upload a target PDF file and try again. ")
             return gr.update(visible=False)
-        
+
+        # Prevent TypeError when accordion not opened (recipient is None)
+        recipient = recipient or ""
+
         sender_email = os.environ["SENDER_EMAIL"] if "SENDER_EMAIL" in os.environ else None
         
         if isinstance(target, str):

--- a/frontend/__main__.py
+++ b/frontend/__main__.py
@@ -274,4 +274,8 @@ with gr.Blocks(css=css, js=js_func) as demo:
 
 # Launch Gradio app
 if __name__ == "__main__":
-    demo.launch(server_name="0.0.0.0", root_path=os.environ.get("PROXY_PREFIX"))
+    demo.launch(
+        server_name="0.0.0.0",
+        root_path=os.environ.get("PROXY_PREFIX"),
+        allowed_paths=["/project/frontend/demo_outputs"]  # Allow serving generated podcast files
+    )

--- a/frontend/shared/shared/podcast_types.py
+++ b/frontend/shared/shared/podcast_types.py
@@ -35,7 +35,7 @@ class DialogueEntry(BaseModel):
 
 
 class Conversation(BaseModel):
-    scratchpad: str
+    scratchpad: str = ""
     dialogue: List[DialogueEntry]
 
 

--- a/models.json
+++ b/models.json
@@ -4,11 +4,11 @@
     "api_base": "https://integrate.api.nvidia.com/v1"
   },
   "json": {
-    "name": "meta/llama-3.1-8b-instruct",
+    "name": "meta/llama-3.1-70b-instruct",
     "api_base": "https://integrate.api.nvidia.com/v1"
   },
   "iteration": {
-    "name": "meta/llama-3.1-70b-instruct",
+    "name": "meta/llama-3.1-405b-instruct",
     "api_base": "https://integrate.api.nvidia.com/v1"
   }
 }

--- a/services/AgentService/podcast_flow.py
+++ b/services/AgentService/podcast_flow.py
@@ -199,7 +199,6 @@ async def podcast_generate_structured_outline(
         "enum": valid_filenames,
     }
 
-    schema = PodcastOutline.model_json_schema()
     template = PodcastPrompts.get_template(
         "podcast_multi_pdf_structured_outline_prompt"
     )

--- a/services/AgentService/podcast_prompts.py
+++ b/services/AgentService/podcast_prompts.py
@@ -91,7 +91,7 @@ Convert the following outline into a structured JSON format. The final section s
 Output Requirements:
 1. Each segment must include:
    - section name
-   - duration (in minutes) representing the length of the segment
+   - duration (in seconds) representing the length of the segment
    - list of references (file paths)
    - list of topics, where each topic has:
      - title
@@ -104,8 +104,8 @@ Output Requirements:
 3. Important notes:
    - References must be chosen from this list of valid filenames: {{ valid_filenames }}
    - References should only appear in the segment's "references" array, not as a topic
-   - Duration represents the length of each segment, not its starting timestamp
-   - Each segment's duration should be a positive number
+   - Duration represents the length of each segment in seconds, not its starting timestamp
+   - Each segment's duration MUST be a positive INTEGER in seconds (whole number only, no decimals)
 
 The result must conform to the following JSON schema:
 {{ schema }}

--- a/shared/shared/podcast_types.py
+++ b/shared/shared/podcast_types.py
@@ -46,7 +46,7 @@ class Conversation(BaseModel):
         scratchpad (str): Working notes or context for the conversation
         dialogue (List[DialogueEntry]): List of dialogue entries making up the conversation
     """
-    scratchpad: str
+    scratchpad: str = ""
     dialogue: List[DialogueEntry]
 
 


### PR DESCRIPTION
# Fix validation errors and runtime exceptions in podcast generation workflow

This PR addresses six bugs that cause validation errors and runtime exceptions during podcast generation. Each fix resolves a specific failure point that prevents successful podcast creation.

**Note:** Each fix is implemented as a separate commit for easier review.

---

### Bug Fixes

#### 1. Fix Pydantic validation error from missing scratchpad field
**Files:** `frontend/shared/shared/podcast_types.py`, `shared/shared/podcast_types.py`

**Bug:** The `Conversation.scratchpad` field was required but not instructed to be provided in the prompt, causing Pydantic validation errors.

**Impact:** Podcast generation fails with validation error when scratchpad is omitted.

**Solution:** Added empty string default (`scratchpad: str = ""`) to make the field optional.

---

#### 2. Fix duration unit mismatch between prompt and Pydantic model
**Files:** `services/AgentService/podcast_prompts.py`

**Bug:** The prompt instructed the LLM to output duration in minutes, but the Pydantic model expected integer seconds. This type mismatch caused validation failures.

**Impact:** Every outline generation fails with validation error due to incompatible duration units.

**Solution:** Updated prompt to clearly specify duration must be integer seconds, matching the model's expectation.

---

#### 3. Fix schema regeneration that discards filename enum
**Files:** `services/AgentService/podcast_flow.py`

**Bug:** Code dynamically added filename enum to schema, then immediately regenerated the schema, discarding the enum modifications.

**Impact:** Schema regeneration overrides the dynamic modifications, causing the filename enum constraints to not be applied.

**Solution:** Removed the redundant `schema = PodcastOutline.model_json_schema()` call that was overriding the enum modifications.

---

#### 4. Align models.json with llmmanager.py defaults
**Files:** `models.json`

**Bug:** Configuration mismatch between `models.json` and hardcoded defaults in `llmmanager.py`:
- JSON role: models.json used `llama-3.1-8b-instruct`, code defaults to `llama-3.1-70b-instruct`
- Iteration role: models.json used `llama-3.1-70b-instruct`, code defaults to `llama-3.1-405b-instruct`

**Impact:** Using the 8B model for JSON generation causes frequent Pydantic validation errors due to lower model capacity (NVIDIA hosted models).

**Solution:** Updated `models.json` to match the code defaults, ensuring consistent model usage.

---

#### 5. Fix TypeError when recipient field is None
**Files:** `frontend/__main__.py`

**Bug:** The `recipient` field is `None` by default unless the user clicks the accordion. Code attempts `len(recipient)` without null check, causing `TypeError: object of type 'NoneType' has no len()`.

**Impact:** Podcast generation fails immediately unless user explicitly opens the recipient accordion (even if not providing a value).

**Solution:** Added null coalescing: `recipient = recipient or ""` to handle the default None case.

---

#### 6. Fix Gradio InvalidPathError for audio and transcript files
**Files:** `frontend/__main__.py`

**Bug:** Gradio raises `InvalidPathError` when attempting to serve generated audio and transcript files.

**Impact:** Users cannot download generated podcast audio or transcripts through the web UI.

**Solution:** Resolved path handling to ensure Gradio can correctly serve generated files.

---

### Testing

All fixes have been tested and verified to resolve their respective issues.

### Impact Summary

These fixes enable successful end-to-end podcast generation by resolving:
- 4 Pydantic validation errors
- 2 runtime exceptions

Without these fixes, the podcast generation workflow fails at multiple points.