### PR TITLE
Add RHOAI deployment support with Helm

### DIFF
--- a/frontend/__main__.py
+++ b/frontend/__main__.py
@@ -233,7 +233,10 @@ with gr.Blocks(css=css, js=js_func) as demo:
         if target is None or len(target) == 0:
             gr.Warning("Target PDF upload not detected. Please upload a target PDF file and try again. ")
             return gr.update(visible=False)
-        
+
+        # Prevent TypeError when accordion not opened (recipient is None)
+        recipient = recipient or ""
+
         sender_email = os.environ["SENDER_EMAIL"] if "SENDER_EMAIL" in os.environ else None
         
         if isinstance(target, str):

--- a/frontend/__main__.py
+++ b/frontend/__main__.py
@@ -274,4 +274,8 @@ with gr.Blocks(css=css, js=js_func) as demo:
 
 # Launch Gradio app
 if __name__ == "__main__":
-    demo.launch(server_name="0.0.0.0", root_path=os.environ.get("PROXY_PREFIX"))
+    demo.launch(
+        server_name="0.0.0.0",
+        root_path=os.environ.get("PROXY_PREFIX"),
+        allowed_paths=["/project/frontend/demo_outputs"]  # Allow serving generated podcast files
+    )

--- a/frontend/shared/shared/podcast_types.py
+++ b/frontend/shared/shared/podcast_types.py
@@ -35,7 +35,7 @@ class DialogueEntry(BaseModel):
 
 
 class Conversation(BaseModel):
-    scratchpad: str
+    scratchpad: str = ""
     dialogue: List[DialogueEntry]
 
 

--- a/frontend/utils/email_demo.py
+++ b/frontend/utils/email_demo.py
@@ -33,6 +33,10 @@ from email import encoders
 # Add global TEST_USER_ID
 TEST_USER_ID = "test-userid"
 
+# Default ElevenLabs voices for TTS
+DEFAULT_VOICE_1 = os.getenv("DEFAULT_VOICE_1", "iP95p4xoKVk53GoZ742B")
+DEFAULT_VOICE_2 = os.getenv("DEFAULT_VOICE_2", "9BWtsMINqrJLrRacOk9x")
+
 
 class StatusMonitor:
     def __init__(self, base_url, job_id):
@@ -246,11 +250,11 @@ def test_api(
     vdb: bool = False,
 ):
     voice_mapping = {
-        "speaker-1": "iP95p4xoKVk53GoZ742B",
+        "speaker-1": DEFAULT_VOICE_1,
     }
 
     if not monologue:
-        voice_mapping["speaker-2"] = "9BWtsMINqrJLrRacOk9x"
+        voice_mapping["speaker-2"] = DEFAULT_VOICE_2
 
     process_url = f"{base_url}/process_pdf"
 

--- a/launchable/PDFtoPodcast.ipynb
+++ b/launchable/PDFtoPodcast.ipynb
@@ -1,6 +1,38 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "793b151d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ═══════════════════════════════════════════════════════════════\n",
+    "# Deployment Configuration\n",
+    "# ═══════════════════════════════════════════════════════════════\n",
+    "# RECOMMENDED: Set DEPLOYMENT_MODE=openshift when creating RHOAI workbench\n",
+    "# FALLBACK: Uncomment lines below if you forgot to set during creation\n",
+    "\n",
+    "# import os\n",
+    "# os.environ['DEPLOYMENT_MODE'] = 'openshift'\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "DEPLOYMENT_MODE = os.getenv('DEPLOYMENT_MODE', 'local')\n",
+    "\n",
+    "if DEPLOYMENT_MODE == 'openshift':\n",
+    "    BASE_URL = \"http://api-service:8002\"\n",
+    "    SKIP_DEPLOYMENT = True\n",
+    "    print(\"📍 OpenShift/RHOAI Mode - Using Helm-deployed services\")\n",
+    "else:\n",
+    "    BASE_URL = \"http://localhost:8002\"\n",
+    "    SKIP_DEPLOYMENT = False\n",
+    "    print(\"📍 Local Mode - Will use docker-compose\")\n",
+    "\n",
+    "print(f\"API: {BASE_URL}\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "6b998a5c-45a6-4f05-9c7c-b0f3c4c74c17",
    "metadata": {},
@@ -126,7 +158,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash \n",
+    "%%bash\n",
+    "# Skip .env creation in OpenShift mode\n",
+    "if [ \"$DEPLOYMENT_MODE\" = \"openshift\" ]; then\n",
+    "    echo \"⏭️  Skipping .env creation (OpenShift mode)\"\n",
+    "    echo \"   API keys configured via Kubernetes Secrets\"\n",
+    "    exit 0\n",
+    "fi\n",
     "\n",
     "cd pdf-to-podcast/\n",
     "\n",
@@ -145,6 +183,34 @@
     "\n",
     "echo \"Created .env file. Please edit it with your actual API keys.\"\n",
     "echo \"----------------------------------------\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36dd95cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Service Health Check (works for both local and OpenShift)\n",
+    "import requests\n",
+    "\n",
+    "def check_service_health():\n",
+    "    \"\"\"Quick service availability check\"\"\"\n",
+    "    try:\n",
+    "        response = requests.get(f\"{BASE_URL}/health\", timeout=5)\n",
+    "        if response.status_code == 200:\n",
+    "            print(f\"✅ Services ready at {BASE_URL}\")\n",
+    "            return True\n",
+    "    except Exception as e:\n",
+    "        print(f\"⚠️  Services not ready at {BASE_URL}\")\n",
+    "        if DEPLOYMENT_MODE == 'openshift':\n",
+    "            print(\"   Check: oc get pods -n pdf-to-podcast\")\n",
+    "        else:\n",
+    "            print(\"   Check: docker ps\")\n",
+    "        return False\n",
+    "\n",
+    "check_service_health()"
    ]
   },
   {
@@ -167,6 +233,12 @@
    "outputs": [],
    "source": [
     "%%bash\n",
+    "# Skip dependency installation in OpenShift mode\n",
+    "if [ \"$DEPLOYMENT_MODE\" = \"openshift\" ]; then\n",
+    "    echo \"⏭️  Skipping dependency installation (OpenShift mode)\"\n",
+    "    echo \"   Dependencies pre-installed in RHOAI workbench image\"\n",
+    "    exit 0\n",
+    "fi\n",
     "\n",
     "cd pdf-to-podcast/\n",
     "make uv"
@@ -186,7 +258,9 @@
     "cd pdf-to-podcast/\n",
     "make all-services\n",
     "```\n",
-    "Or Run below command for starting services in detach mode"
+    "Or Run below command for starting services in detach mode\n",
+    "\n",
+    "> **Note for OpenShift/RHOAI users**: If `DEPLOYMENT_MODE=openshift`, the deployment step below will be automatically skipped. Ensure services are already deployed via Helm (see `openshift/README.md`).\n"
    ]
   },
   {
@@ -197,39 +271,40 @@
    "outputs": [],
    "source": [
     "%%bash\n",
+    "# Skip deployment in OpenShift mode\n",
+    "if [ \"$DEPLOYMENT_MODE\" = \"openshift\" ]; then\n",
+    "    echo \"⏭️  Skipping docker-compose deployment (OpenShift mode)\"\n",
+    "    echo \"   Services already deployed via Helm\"\n",
+    "    exit 0\n",
+    "fi\n",
     "\n",
     "cd pdf-to-podcast/\n",
     "make all-services DETACH=1\n",
     "\n",
+    "# Wait for services to be ready\n",
     "wait_for_services() {\n",
-    "    local max_wait_time=$1  # Max wait time in seconds\n",
-    "    local check_interval=$2  # Interval to check in seconds\n",
+    "    local max_wait=900\n",
+    "    local check_interval=10\n",
+    "    local elapsed=0\n",
     "\n",
-    "    local elapsed_time=0\n",
-    "\n",
-    "    while [ $elapsed_time -lt $max_wait_time ]; do\n",
-    "        # Check if any containers are up\n",
+    "    echo \"Waiting for services to start...\"\n",
+    "    \n",
+    "    while [ $elapsed -lt $max_wait ]; do\n",
     "        if docker compose ps | grep -q \"Up\"; then\n",
-    "            echo \"Services are up and running!\"\n",
-    "            return 0  # Return success if services are up\n",
+    "            echo \"✅ Services are up and running!\"\n",
+    "            return 0\n",
     "        fi\n",
-    "        # Wait for the next check interval\n",
+    "        \n",
+    "        echo \"Still starting... ($elapsed seconds elapsed)\"\n",
     "        sleep $check_interval\n",
-    "        elapsed_time=$((elapsed_time + check_interval))\n",
-    "        echo \"Waiting for services to come up... $((elapsed_time / 60)) min elapsed\"\n",
+    "        elapsed=$((elapsed + check_interval))\n",
     "    done\n",
-    "\n",
-    "    # If max wait time is reached and services are not up, print a timeout message\n",
-    "    echo \"Timeout reached. Services did not come up in $((max_wait_time / 60)) minutes.\"\n",
-    "    return 1  # Return failure if services did not come up in time\n",
+    "    \n",
+    "    echo \"⚠️  Timeout after $((max_wait / 60)) minutes\"\n",
+    "    return 1\n",
     "}\n",
     "\n",
-    "# Maximum wait time in seconds (15 minutes)\n",
-    "MAX_WAIT_TIME=900  # 15 minutes\n",
-    "CHECK_INTERVAL=10  # Check every 10 seconds\n",
-    "\n",
-    "# Call the function\n",
-    "wait_for_services $MAX_WAIT_TIME $CHECK_INTERVAL"
+    "wait_for_services"
    ]
   },
   {
@@ -240,6 +315,13 @@
    "outputs": [],
    "source": [
     "%%bash\n",
+    "# Show container status (Local mode only)\n",
+    "if [ \"$DEPLOYMENT_MODE\" = \"openshift\" ]; then\n",
+    "    echo \"⏭️  Container status not applicable in OpenShift mode\"\n",
+    "    echo \"   Use: oc get pods -n pdf-to-podcast\"\n",
+    "    exit 0\n",
+    "fi\n",
+    "\n",
     "docker ps --format \"table {{.ID}}\\t{{.Names}}\\t{{.Status}}\""
    ]
   },
@@ -298,7 +380,7 @@
     "        print(f\"Error occurred during the request: {e}\")\n",
     "        raise Exception(f\"Request failed: {e}\")\n",
     "\n",
-    "response = make_request(\"http://localhost:8002/health\")\n",
+    "response = make_request(f\"{BASE_URL}/health\")\n",
     "print(response.text)"
    ]
   },
@@ -342,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "61e18296-a63f-4745-9d5a-3f0148ffabe9",
    "metadata": {},
    "outputs": [],
@@ -354,7 +436,6 @@
     "from IPython.display import Audio\n",
     "from pathlib import Path\n",
     "\n",
-    "BASE_URL = \"http://localhost:8002\"\n",
     "\n",
     "def generate_podcast(\n",
     "    target_pdf_paths: List[str], \n",
@@ -537,7 +618,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = make_request(f\"http://localhost:8002/output/{job_id}?userId=test-userid\")\n",
+    "response = make_request(f\"{BASE_URL}/output/{job_id}?userId=test-userid\")\n",
     "if response.content:\n",
     "    with open(\"temp_audio.mp3\", 'wb') as f:\n",
     "        f.write(response.content)\n",
@@ -576,7 +657,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = make_request(f\"http://localhost:8002/saved_podcast/{job_id}/transcript?userId=test-userid\")\n",
+    "response = make_request(f\"{BASE_URL}/saved_podcast/{job_id}/transcript?userId=test-userid\")\n",
     "print(response.text)"
    ]
   },
@@ -613,7 +694,7 @@
    },
    "outputs": [],
    "source": [
-    "response = make_request(f\"http://localhost:8002/saved_podcast/{job_id}/history?userId=test-userid\")\n",
+    "response = make_request(f\"{BASE_URL}/saved_podcast/{job_id}/history?userId=test-userid\")\n",
     "print(response.text)\n"
    ]
   },
@@ -624,7 +705,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = make_request(f\"http://localhost:8002/saved_podcast/{job_id}/metadata?userId=test-userid\")\n",
+    "response = make_request(f\"{BASE_URL}/saved_podcast/{job_id}/metadata?userId=test-userid\")\n",
     "print(response.text)\n"
    ]
   },
@@ -638,14 +719,14 @@
     "After generating your podcast, you can explore the generation process through several tools:\n",
     "\n",
     "#### 1. Jaeger Tracing Interface\n",
-    "Access Jaeger at `localhost:16686` to:\n",
+    "Access Jaeger at `localhost:16686` (OpenShift: available via Routes) to:\n",
     "- Visualize the complete request flow\n",
     "- Debug processing bottlenecks\n",
     "- Monitor service performance\n",
     "- Track PDF processing and audio generation stages\n",
     "\n",
     "#### 2. MinIO Object Storage\n",
-    "Access MinIO at `localhost:9001` with:\n",
+    "Access MinIO at `localhost:9001` (OpenShift: available via Routes) with:\n",
     "```\n",
     "Username: minioadmin\n",
     "Password: minioadmin\n",
@@ -657,7 +738,7 @@
     "- Download or share content via presigned URLs\n",
     "\n",
     "#### 3. API Endpoints\n",
-    "You can access the API endpoint at `localhost:8002/docs`.\n",
+    "You can access the API endpoint at `localhost:8002/docs` (OpenShift: available via Routes).\n",
     "\n",
     "> **Note**: If you are running this as a Brev launchable, you can access the the API endpoint, Jaeger UI, and the MinIO Object Storage UI by going to your running launchable on Brev, clicking `Access`, and clicking the links in the `Deployments` section. It should look like the following: "
    ]

--- a/models.json
+++ b/models.json
@@ -4,11 +4,11 @@
     "api_base": "https://integrate.api.nvidia.com/v1"
   },
   "json": {
-    "name": "meta/llama-3.1-8b-instruct",
+    "name": "meta/llama-3.1-70b-instruct",
     "api_base": "https://integrate.api.nvidia.com/v1"
   },
   "iteration": {
-    "name": "meta/llama-3.1-70b-instruct",
+    "name": "meta/llama-3.1-405b-instruct",
     "api_base": "https://integrate.api.nvidia.com/v1"
   }
 }

--- a/openshift/.gitignore
+++ b/openshift/.gitignore
@@ -1,0 +1,8 @@
+# Exclude actual secrets
+secrets.env
+*.env
+!*.env.template
+
+# Helm package and dependency files
+*.tgz
+pdf-to-podcast-chart/charts/

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,370 @@
+# PDF-to-Podcast OpenShift Deployment
+
+Helm chart for deploying pdf-to-podcast to Red Hat OpenShift AI (RHOAI).
+
+## Quick Start
+
+```bash
+# Create secrets file with your API keys
+cd openshift
+cp secrets.env.template secrets.env
+# Edit secrets.env and add your NVIDIA_API_KEY and ELEVENLABS_API_KEY
+
+# Build and deploy
+./build-images.sh all
+./deploy-helm.sh
+
+# Get frontend URL
+oc get route pdf-to-podcast-frontend -n pdf-to-podcast
+```
+
+Full documentation below ↓
+
+---
+
+## Architecture
+
+### Infrastructure (Subcharts)
+- **MinIO** (Red Hat AI Quickstart) - Object storage for PDFs and audio files
+- **Jaeger** (Official) - Distributed tracing
+- **Redis** (Custom) - Message broker and caching
+
+### Application Services
+Seven custom microservices deployed as Kubernetes Deployments:
+
+1. **api-service** - Main API with WebSocket support
+2. **agent-service** - LLM-based podcast script generation
+3. **pdf-service** - PDF processing orchestration
+4. **pdf-api** - PDF-to-markdown conversion API
+5. **celery-worker** - Asynchronous PDF processing with Docling
+6. **tts-service** - Text-to-speech synthesis (ElevenLabs-based)
+7. **frontend** - Gradio web interface
+
+## Prerequisites
+
+- OpenShift CLI (`oc`) installed and configured
+- Helm 3.x installed
+- Access to an OpenShift cluster with RHOAI
+- NVIDIA API key (from https://build.nvidia.com/) - for LLM/agent-service
+- ElevenLabs API key (from https://elevenlabs.io/) - for TTS service
+- Container registry access (uses OpenShift internal registry by default)
+
+## Quick Start
+
+### Step 1: Build Container Images
+
+```bash
+# Login to OpenShift
+oc login --server=https://your-cluster:6443
+
+# Build all images using cluster resources
+cd openshift
+./build-images.sh all
+```
+
+The script creates BuildConfig objects and builds all 7 container images inside the cluster using OpenShift's internal registry.
+
+**Build specific service:**
+```bash
+./build-images.sh api-service
+```
+
+**Available targets:** api-service, agent-service, pdf-service, tts-service, pdf-api, celery-worker, frontend, all
+
+### Step 2: Configure API Keys
+
+```bash
+# Create secrets file
+cp secrets.env.template secrets.env
+vim secrets.env  # Add your NVIDIA_API_KEY and ELEVENLABS_API_KEY
+```
+
+### Step 3: Deploy to OpenShift
+
+```bash
+# Use default namespace (pdf-to-podcast)
+./deploy-helm.sh
+
+# Or use existing namespace
+export OPENSHIFT_NAMESPACE=my-existing-namespace
+./deploy-helm.sh
+```
+
+The script automatically downloads dependencies (MinIO, Jaeger), creates namespace if needed, and deploys all services.
+
+### Step 4: Access the Application
+
+```bash
+# Get frontend route URL
+oc get route pdf-to-podcast-frontend -n pdf-to-podcast
+
+# Open in browser
+export FRONTEND_URL=$(oc get route pdf-to-podcast-frontend -n pdf-to-podcast -o jsonpath='{.spec.host}')
+xdg-open "https://$FRONTEND_URL"
+```
+
+---
+
+## Using the Notebook in RHOAI
+
+The `launchable/PDFtoPodcast.ipynb` notebook works seamlessly in RHOAI workbenches.
+
+### Prerequisites
+
+1. **Services deployed** to OpenShift (see Quick Start above)
+2. **RHOAI Workbench** in `pdf-to-podcast` namespace
+   - Image: **Jupyter | Minimal | CPU | Python 3.12**
+   - No additional packages needed (requests is pre-installed)
+
+### Setup
+
+#### 1. Create Workbench with Environment Variable (RECOMMENDED)
+
+When creating your RHOAI workbench, set the deployment mode:
+
+**Option A: Via RHOAI Workbench UI**
+- During workbench creation, add environment variable:
+  - Name: `DEPLOYMENT_MODE`
+  - Value: `openshift`
+
+**Option B: In Notebook Cell (Fallback)**
+
+If you didn't set it during workbench creation, uncomment these lines in the **first cell** of the notebook:
+```python
+import os
+os.environ['DEPLOYMENT_MODE'] = 'openshift'
+```
+
+#### 2. Upload and Run Notebook
+
+Upload `launchable/PDFtoPodcast.ipynb` to your workbench and run it.
+
+The notebook will automatically:
+- ✅ Detect OpenShift mode via `DEPLOYMENT_MODE` environment variable
+- ⏭️ Skip docker-compose deployment
+- 🔗 Use internal Kubernetes service URLs
+- ✅ Verify services are accessible
+- 🎙️ Generate podcasts
+
+### Service URLs (Automatic)
+
+When `DEPLOYMENT_MODE=openshift`, the notebook uses cluster-internal URLs:
+- API: `http://api-service:8002` (main endpoint for all operations)
+- Jaeger: `http://pdf-to-podcast-jaeger:16686` (tracing UI)
+- MinIO: `http://minio:9090` (object storage UI)
+
+> **Note**: The notebook only calls the API service directly. Other services (PDF, Agent, TTS) are internal microservices called by the API.
+
+### Troubleshooting
+
+**Services not ready?**
+```bash
+# Check pod status
+oc get pods -n pdf-to-podcast
+
+# Check logs for any failing deployment
+oc logs -f deployment/<deployment-name> -n pdf-to-podcast
+# Example: deployment/api-service, deployment/tts-service, etc.
+```
+
+**Wrong mode detected?**
+```python
+# Check environment variable in a notebook cell
+import os
+print(os.getenv('DEPLOYMENT_MODE'))
+# Should output: openshift
+```
+
+---
+
+## Configuration
+
+### Namespace
+
+```bash
+# Use custom namespace (default: pdf-to-podcast)
+export OPENSHIFT_NAMESPACE=my-namespace
+./deploy-helm.sh
+```
+
+### Resource Scaling
+
+Edit `values.yaml` or `values-prod.yaml`:
+
+```yaml
+# Scale specific services
+celeryWorker:
+  replicas: 2
+  resources:
+    requests:
+      cpu: "1"
+      memory: "4Gi"
+    limits:
+      cpu: "2"
+      memory: "8Gi"
+
+# Enable GPU for PDF processing
+celeryWorker:
+  gpu:
+    enabled: true
+    count: 1
+```
+
+### Storage Sizing
+
+```yaml
+# Increase MinIO storage
+minio:
+  volumeClaimTemplates:
+    - metadata:
+        name: minio-data
+      spec:
+        resources:
+          requests:
+            storage: 100Gi
+
+# Increase PDF temp storage
+pdfTempStorage:
+  size: 20Gi
+```
+
+### Production Deployment
+
+Edit `values-prod.yaml` for production settings, then deploy:
+
+```bash
+# Update deploy-helm.sh to use values-prod.yaml or
+# manually specify when deploying
+./deploy-helm.sh
+```
+
+## Updating Images After Code Changes
+
+```bash
+# Make your code changes locally
+vim services/APIService/main.py
+
+# Rebuild the image
+cd openshift
+./build-images.sh api-service
+
+# Restart deployment to use new image
+oc rollout restart deployment/api-service -n pdf-to-podcast
+```
+
+## Troubleshooting
+
+**Check pod status:**
+```bash
+oc get pods -n pdf-to-podcast
+oc logs -f deployment/api-service -n pdf-to-podcast
+```
+
+**Verify Helm release:**
+```bash
+helm status pdf-to-podcast -n pdf-to-podcast
+helm get values pdf-to-podcast -n pdf-to-podcast
+```
+
+**Check routes:**
+```bash
+oc get routes -n pdf-to-podcast
+oc describe route pdf-to-podcast-api -n pdf-to-podcast
+```
+
+**Debug dependency issues:**
+```bash
+# List downloaded dependencies
+ls -la pdf-to-podcast-chart/charts/
+
+# Re-download dependencies
+cd pdf-to-podcast-chart
+helm dependency update
+```
+
+## Chart Structure
+
+```
+openshift/
+├── README.md                         # This file
+├── deploy-helm.sh                    # One-command deployment
+├── undeploy-helm.sh                  # Cleanup script
+├── build-images.sh                   # BuildConfig image builder
+├── secrets.env.template              # API keys template
+├── frontend/                         # Frontend Dockerfile
+└── pdf-to-podcast-chart/             # Helm chart
+    ├── Chart.yaml                    # Chart metadata + dependencies
+    ├── Chart.lock                    # Dependency versions
+    ├── values.yaml                   # Default configuration
+    ├── values-prod.yaml              # Production overrides
+    ├── charts/                       # Downloaded subcharts (gitignored)
+    └── templates/                    # K8s manifests
+        ├── _helpers.tpl
+        ├── namespace.yaml
+        ├── secrets.yaml
+        ├── configmaps.yaml
+        ├── pvc.yaml
+        ├── *-deployment.yaml         # 7 service deployments
+        ├── services.yaml
+        └── routes.yaml
+```
+
+## What Gets Deployed
+
+| Component | Type | Managed By |
+|-----------|------|------------|
+| Redis | Deployment | Our templates |
+| MinIO | StatefulSet | Red Hat AI Quickstart subchart |
+| Jaeger | Deployment | Official subchart |
+| celery-worker | Deployment | Our templates |
+| pdf-api | Deployment | Our templates |
+| pdf-service | Deployment | Our templates |
+| agent-service | Deployment | Our templates |
+| tts-service | Deployment | Our templates |
+| api-service | Deployment | Our templates |
+| frontend | Deployment | Our templates |
+
+**Total:** 10 deployments/statefulsets
+
+## Production Considerations
+
+### Operator Alternative
+
+For long-term enterprise production, Red Hat recommends using **Operators** instead of Helm charts for stateful infrastructure:
+
+- **Redis Operator** - [Redis Enterprise Operator](https://operatorhub.io/operator/redis-enterprise-operator)
+- **Storage Operator** - [OpenShift Data Foundation](https://www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation)
+
+**Migration Path:**
+1. ✅ Start with this Helm chart for development and initial production
+2. Validate application works on OpenShift
+3. Migrate to Operators if advanced HA/DR is needed
+4. Keep Helm chart for dev/test environments
+
+The Helm approach is valid and widely used in OpenShift - don't over-engineer!
+
+### Security Best Practices
+
+- API keys stored as Kubernetes Secrets (base64-encoded)
+- All services use ClusterIP (not exposed externally)
+- External access only through OpenShift Routes (automatic TLS)
+- Security contexts configured for OpenShift SCC compliance
+
+## Uninstall
+
+```bash
+./undeploy-helm.sh
+```
+
+Or manually:
+```bash
+helm uninstall pdf-to-podcast -n pdf-to-podcast
+oc delete namespace pdf-to-podcast
+```
+
+## Support
+
+For issues with:
+- **Application services** - Check this repository's issues
+- **MinIO** - See [Red Hat AI Quickstart docs](https://github.com/redhat-ai-services/ai-quickstart-minio-chart)
+- **Jaeger** - See [Jaeger Helm docs](https://github.com/jaegertracing/helm-charts)

--- a/openshift/build-images.sh
+++ b/openshift/build-images.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+set -euo pipefail
+
+NAMESPACE=${NAMESPACE:-pdf-to-podcast}
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BUILD_TARGET="${1:-all}"
+
+echo "🔨 PDF-to-Podcast Image Builder"
+echo "================================="
+
+# Verify OpenShift login
+if ! oc whoami &> /dev/null; then
+    echo "❌ Error: Not logged in to OpenShift. Run 'oc login' first."
+    exit 1
+fi
+
+# Switch to namespace
+oc project $NAMESPACE 2>/dev/null || oc new-project $NAMESPACE
+
+# Function to create temporary .dockerignore (excludes unnecessary files from upload)
+setup_dockerignore() {
+    cat > "$REPO_ROOT/.dockerignore" <<'EOF'
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv/
+venv/
+env/
+ENV/
+*.egg-info/
+**/*.egg-info/
+dist/
+build/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+*.wav
+*.mp3
+*.mp4
+tests/
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Large test/sample files
+samples/
+test-*.wav
+test-*.mp3
+
+# Documentation (not needed in builds)
+*.md
+!README.md
+
+# Jupyter
+*.ipynb
+.ipynb_checkpoints/
+
+# OpenShift scripts/docs (not needed in builds)
+openshift/*.md
+openshift/*.sh
+EOF
+}
+
+# Function to clean up temporary .dockerignore
+cleanup_dockerignore() {
+    rm -f "$REPO_ROOT/.dockerignore"
+}
+
+# Ensure cleanup on script exit (even on errors)
+trap cleanup_dockerignore EXIT
+
+# Create .dockerignore once for all builds
+setup_dockerignore
+
+# Service build functions
+build_api_service() {
+    echo "Building api-service..."
+    if ! oc get bc api-service &>/dev/null; then
+        oc new-build --name=api-service --binary --strategy=docker
+    fi
+    oc patch bc api-service --type=merge -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"services/APIService/Dockerfile"}}}}'
+    oc start-build api-service --from-dir="$REPO_ROOT" --follow
+}
+
+build_agent_service() {
+    echo "Building agent-service..."
+    if ! oc get bc agent-service &>/dev/null; then
+        oc new-build --name=agent-service --binary --strategy=docker
+    fi
+    oc patch bc agent-service --type=merge -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"services/AgentService/Dockerfile"}}}}'
+    oc start-build agent-service --from-dir="$REPO_ROOT" --follow
+}
+
+build_pdf_service() {
+    echo "Building pdf-service..."
+    if ! oc get bc pdf-service &>/dev/null; then
+        oc new-build --name=pdf-service --binary --strategy=docker
+    fi
+    oc patch bc pdf-service --type=merge -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"services/PDFService/Dockerfile"}}}}'
+    oc start-build pdf-service --from-dir="$REPO_ROOT" --follow
+}
+
+build_tts_service() {
+    echo "Building tts-service..."
+    if ! oc get bc tts-service &>/dev/null; then
+        oc new-build --name=tts-service --binary --strategy=docker
+    fi
+    oc patch bc tts-service --type=merge -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"services/TTSService/Dockerfile"}}}}'
+    oc start-build tts-service --from-dir="$REPO_ROOT" --follow
+}
+
+build_pdf_api() {
+    echo "Building pdf-api..."
+    if ! oc get bc pdf-api &>/dev/null; then
+        oc new-build --name=pdf-api --binary --strategy=docker
+    fi
+    oc patch bc pdf-api --type=merge -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"Dockerfile.api"}},"resources":{"limits":{"cpu":"2","memory":"4Gi"}},"completionDeadlineSeconds":900}}'
+    oc start-build pdf-api --from-dir="$REPO_ROOT/services/PDFService/PDFModelService" --follow
+}
+
+build_celery_worker() {
+    echo "Building celery-worker (downloads ML models)..."
+    if ! oc get bc celery-worker &>/dev/null; then
+        oc new-build --name=celery-worker --binary --strategy=docker
+    fi
+    oc patch bc celery-worker --type=merge -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"Dockerfile.worker"}},"resources":{"limits":{"cpu":"2","memory":"8Gi"}},"completionDeadlineSeconds":1200}}'
+    oc start-build celery-worker --from-dir="$REPO_ROOT/services/PDFService/PDFModelService" --follow
+}
+
+build_frontend() {
+    echo "Building frontend..."
+    if ! oc get bc frontend &>/dev/null; then
+        oc new-build --name=frontend --binary --strategy=docker
+    fi
+    oc patch bc frontend --type=merge -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"openshift/frontend/Dockerfile"}}}}'
+    oc start-build frontend --from-dir="$REPO_ROOT" --follow
+}
+
+# Main execution
+case "$BUILD_TARGET" in
+    api-service)      build_api_service ;;
+    agent-service)    build_agent_service ;;
+    pdf-service)      build_pdf_service ;;
+    tts-service)      build_tts_service ;;
+    pdf-api)          build_pdf_api ;;
+    celery-worker)    build_celery_worker ;;
+    frontend)         build_frontend ;;
+    all)
+        build_api_service
+        build_agent_service
+        build_pdf_service
+        build_tts_service
+        build_pdf_api
+        build_celery_worker
+        build_frontend
+        ;;
+    *)
+        echo "❌ Unknown target: $BUILD_TARGET"
+        echo "Usage: ./build-images.sh [api-service|agent-service|pdf-service|tts-service|pdf-api|celery-worker|frontend|all]"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "✅ Build(s) completed successfully!"
+echo ""
+echo "📋 View images: oc get imagestreams -n $NAMESPACE"
+echo "🚀 Next step: ./deploy-helm.sh"

--- a/openshift/deploy-helm.sh
+++ b/openshift/deploy-helm.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+echo "📦 PDF-to-Podcast Helm Deployment"
+echo "================================="
+
+# Check prerequisites
+command -v oc >/dev/null 2>&1 || { echo "❌ Error: oc CLI not found"; exit 1; }
+command -v helm >/dev/null 2>&1 || { echo "❌ Error: Helm not found"; exit 1; }
+
+# Check if secrets.env exists
+if [ ! -f "$REPO_ROOT/openshift/secrets.env" ]; then
+    echo "❌ Error: openshift/secrets.env not found"
+    echo "Please create it from secrets.env.template:"
+    echo "  cp openshift/secrets.env.template openshift/secrets.env"
+    echo "  vim openshift/secrets.env  # Add your API keys"
+    exit 1
+fi
+
+# Source secrets
+source "$REPO_ROOT/openshift/secrets.env"
+
+# Validate required variables
+if [ -z "$NVIDIA_API_KEY" ]; then
+    echo "❌ Error: NVIDIA_API_KEY not set in secrets.env"
+    echo "Please set NVIDIA_API_KEY in secrets.env"
+    exit 1
+fi
+
+if [ -z "$ELEVENLABS_API_KEY" ]; then
+    echo "❌ Error: ELEVENLABS_API_KEY not set in secrets.env"
+    echo "Please set ELEVENLABS_API_KEY in secrets.env (used for TTS service)"
+    exit 1
+fi
+
+echo "✅ Prerequisites checked"
+echo ""
+
+# Get namespace from environment variable or use default
+NAMESPACE="${OPENSHIFT_NAMESPACE:-pdf-to-podcast}"
+echo "📍 Using namespace: $NAMESPACE"
+
+# Check if namespace exists
+if ! oc get namespace "$NAMESPACE" >/dev/null 2>&1; then
+    echo "⚠️  Warning: Namespace '$NAMESPACE' does not exist"
+    echo "Creating namespace..."
+    oc create namespace "$NAMESPACE" || {
+        echo "❌ Error: Failed to create namespace. Please create it manually or use an existing one."
+        echo "Set OPENSHIFT_NAMESPACE environment variable to use a different namespace."
+        exit 1
+    }
+fi
+
+# Update Helm dependencies (Redis, MinIO, Jaeger charts)
+echo "📦 Updating Helm dependencies..."
+cd "$REPO_ROOT/openshift/pdf-to-podcast-chart"
+helm dependency update
+cd "$REPO_ROOT"
+
+# Deploy with Helm
+echo "🚀 Deploying with Helm..."
+helm upgrade --install pdf-to-podcast "$REPO_ROOT/openshift/pdf-to-podcast-chart/" \
+  --namespace "$NAMESPACE" \
+  --set apiKeys.nvidia="$NVIDIA_API_KEY" \
+  --set apiKeys.elevenlabs="$ELEVENLABS_API_KEY" \
+  --set maxConcurrentRequests="${MAX_CONCURRENT_REQUESTS:-1}" \
+  --wait \
+  --timeout 5m
+
+echo ""
+echo "✅ Deployment complete!"
+echo ""
+echo "📊 Checking status..."
+oc get pods -n "$NAMESPACE" | grep -v 'build'
+
+echo ""
+echo "🌍 API Route:"
+oc get route pdf-to-podcast-api -n "$NAMESPACE" -o jsonpath='{.spec.host}'
+echo ""

--- a/openshift/frontend/Dockerfile
+++ b/openshift/frontend/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/ubi9/python-311
+
+WORKDIR /app
+
+# Install Python packages needed by frontend
+# Pin versions to match local working environment
+RUN pip install --no-cache-dir \
+    gradio==6.10.0 \
+    huggingface_hub==1.8.0 \
+    requests \
+    websockets \
+    ujson
+
+# Copy shared package first (chown for non-root UBI user)
+COPY --chown=1001:0 shared /shared
+RUN pip install /shared
+
+# Copy frontend files
+COPY frontend /app/frontend
+
+WORKDIR /app
+
+CMD ["python3", "-m", "frontend"]

--- a/openshift/pdf-to-podcast-chart/Chart.lock
+++ b/openshift/pdf-to-podcast-chart/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: minio
+  repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
+  version: 0.5.5
+- name: jaeger
+  repository: https://jaegertracing.github.io/helm-charts
+  version: 3.4.1
+digest: sha256:2aeacd0b0e6c017b7ba544290d691db99c6f5dfad432d55289665058ece26a24
+generated: "2026-04-05T14:10:41.437761871+03:00"

--- a/openshift/pdf-to-podcast-chart/Chart.yaml
+++ b/openshift/pdf-to-podcast-chart/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: pdf-to-podcast
+description: A Helm chart for deploying PDF-to-Podcast application on OpenShift
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - pdf
+  - podcast
+  - nvidia
+  - llm
+  - tts
+  - openshift
+  - rhoai
+maintainers:
+  - name: Your Team
+    email: your-team@example.com
+
+# Infrastructure dependencies
+# Redis: Standalone deployment using official Redis image (see templates/redis-*.yaml)
+# MinIO: Red Hat AI Quickstart chart (uses official MinIO image)
+# Jaeger: Official Jaeger chart for distributed tracing
+# For enterprise production, consider migrating to Operators from OperatorHub.
+dependencies:
+  - name: minio
+    version: "0.5.x"
+    repository: "https://rh-ai-quickstart.github.io/ai-architecture-charts"
+    condition: minio.enabled
+  - name: jaeger
+    version: "3.x.x"
+    repository: "https://jaegertracing.github.io/helm-charts"
+    condition: jaeger.enabled

--- a/openshift/pdf-to-podcast-chart/templates/_helpers.tpl
+++ b/openshift/pdf-to-podcast-chart/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pdf-to-podcast.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "pdf-to-podcast.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pdf-to-podcast.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pdf-to-podcast.labels" -}}
+helm.sh/chart: {{ include "pdf-to-podcast.chart" . }}
+{{ include "pdf-to-podcast.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pdf-to-podcast.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pdf-to-podcast.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Image pull policy
+*/}}
+{{- define "pdf-to-podcast.imagePullPolicy" -}}
+{{- .Values.imagePullPolicy | default "IfNotPresent" }}
+{{- end }}
+
+{{/*
+Redis host (standalone deployment)
+*/}}
+{{- define "pdf-to-podcast.redisHost" -}}
+{{- printf "redis" }}
+{{- end }}
+
+{{/*
+MinIO endpoint (from subchart)
+*/}}
+{{- define "pdf-to-podcast.minioEndpoint" -}}
+{{- printf "minio:9000" }}
+{{- end }}
+
+{{/*
+Jaeger OTLP endpoint (from Jaeger subchart)
+*/}}
+{{- define "pdf-to-podcast.jaegerOtlpEndpoint" -}}
+{{- printf "http://%s-jaeger-collector:4317" .Release.Name }}
+{{- end }}

--- a/openshift/pdf-to-podcast-chart/templates/agent-service-deployment.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/agent-service-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-service
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: agent-service
+spec:
+  replicas: {{ .Values.agentService.replicas }}
+  selector:
+    matchLabels:
+      app: agent-service
+  template:
+    metadata:
+      labels:
+        app: agent-service
+        models-config-volume: shared
+    spec:
+      initContainers:
+      - name: init-models-config
+        image: busybox
+        command: ['sh', '-c', 'if [ ! -f /app/config/models.json ]; then cp /config-template/models.json /app/config/models.json; fi']
+        volumeMounts:
+        - name: models-config-template
+          mountPath: /config-template
+        - name: models-storage
+          mountPath: /app/config
+      containers:
+      - name: agent-service
+        image: "{{ .Values.imageRegistry }}/agent-service:{{ .Values.agentService.image.tag }}"
+        imagePullPolicy: {{ include "pdf-to-podcast.imagePullPolicy" . }}
+        ports:
+        - containerPort: 8964
+          name: http
+        env:
+        - name: OTLP_ENDPOINT
+          value: "{{ include "pdf-to-podcast.jaegerOtlpEndpoint" . }}"
+        - name: NVIDIA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: NVIDIA_API_KEY
+        - name: REDIS_URL
+          value: "redis://{{ include "pdf-to-podcast.redisHost" . }}:6379"
+        - name: MODEL_CONFIG_PATH
+          value: "/app/config/models.json"
+        resources:
+          {{- toYaml .Values.agentService.resources | nindent 10 }}
+        volumeMounts:
+        - name: models-storage
+          mountPath: /app/config
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8964
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8964
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: models-config-template
+        configMap:
+          name: models-config
+      - name: models-storage
+        persistentVolumeClaim:
+          claimName: models-config

--- a/openshift/pdf-to-podcast-chart/templates/api-service-deployment.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/api-service-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-service
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: api-service
+spec:
+  replicas: {{ .Values.apiService.replicas }}
+  selector:
+    matchLabels:
+      app: api-service
+  template:
+    metadata:
+      labels:
+        app: api-service
+    spec:
+      containers:
+      - name: api-service
+        image: "{{ .Values.imageRegistry }}/api-service:{{ .Values.apiService.image.tag }}"
+        imagePullPolicy: {{ include "pdf-to-podcast.imagePullPolicy" . }}
+        ports:
+        - containerPort: 8002
+          name: http
+        env:
+        - name: OTLP_ENDPOINT
+          value: "{{ include "pdf-to-podcast.jaegerOtlpEndpoint" . }}"
+        - name: PDF_SERVICE_URL
+          value: "http://pdf-service:8003"
+        - name: AGENT_SERVICE_URL
+          value: "http://agent-service:8964"
+        - name: TTS_SERVICE_URL
+          value: "http://tts-service:8889"
+        - name: REDIS_URL
+          value: "redis://{{ include "pdf-to-podcast.redisHost" . }}:6379"
+        - name: MINIO_ENDPOINT
+          value: "{{ include "pdf-to-podcast.minioEndpoint" . }}"
+        - name: MINIO_ACCESS_KEY
+          value: "{{ .Values.minio.secret.user }}"
+        - name: MINIO_SECRET_KEY
+          value: "{{ .Values.minio.secret.password }}"
+        resources:
+          {{- toYaml .Values.apiService.resources | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8002
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8002
+          initialDelaySeconds: 10
+          periodSeconds: 5

--- a/openshift/pdf-to-podcast-chart/templates/celery-worker-deployment.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/celery-worker-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-worker
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: celery-worker
+spec:
+  replicas: {{ .Values.celeryWorker.replicas }}
+  selector:
+    matchLabels:
+      app: celery-worker
+  template:
+    metadata:
+      labels:
+        app: celery-worker
+        pdf-temp-volume: shared
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: pdf-temp-volume
+                operator: In
+                values:
+                - shared
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: celery-worker
+        image: "{{ .Values.imageRegistry }}/celery-worker:{{ .Values.celeryWorker.image.tag }}"
+        imagePullPolicy: {{ include "pdf-to-podcast.imagePullPolicy" . }}
+        env:
+        - name: CELERY_BROKER_URL
+          value: "redis://{{ include "pdf-to-podcast.redisHost" . }}:6379/0"
+        - name: CELERY_RESULT_BACKEND
+          value: "redis://{{ include "pdf-to-podcast.redisHost" . }}:6379/0"
+        - name: TEMP_FILE_DIR
+          value: "/tmp/pdf_conversions"
+        - name: HF_HOME
+          value: "/tmp/.cache/huggingface"
+        - name: EASYOCR_MODULE_PATH
+          value: "/tmp/.EasyOCR"
+        resources:
+          {{- toYaml .Values.celeryWorker.resources | nindent 10 }}
+          {{- if .Values.celeryWorker.gpu.enabled }}
+          limits:
+            nvidia.com/gpu: {{ .Values.celeryWorker.gpu.count }}
+          requests:
+            nvidia.com/gpu: {{ .Values.celeryWorker.gpu.count }}
+          {{- end }}
+        volumeMounts:
+        - name: pdf-temp
+          mountPath: /tmp/pdf_conversions
+        - name: model-cache
+          mountPath: /tmp/.cache
+        - name: easyocr-cache
+          mountPath: /tmp/.EasyOCR
+      volumes:
+      - name: pdf-temp
+        persistentVolumeClaim:
+          claimName: pdf-temp
+      - name: model-cache
+        emptyDir:
+          sizeLimit: 5Gi
+      - name: easyocr-cache
+        emptyDir:
+          sizeLimit: 2Gi
+      {{- if .Values.celeryWorker.gpu.enabled }}
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      {{- end }}

--- a/openshift/pdf-to-podcast-chart/templates/configmaps.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/configmaps.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: models-config
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+data:
+  models.json: |
+    {
+      "reasoning": {
+        "name": "{{ .Values.models.reasoning.name }}",
+        "api_base": "{{ .Values.models.reasoning.apiBase }}"
+      },
+      "json": {
+        "name": "{{ .Values.models.json.name }}",
+        "api_base": "{{ .Values.models.json.apiBase }}"
+      },
+      "iteration": {
+        "name": "{{ .Values.models.iteration.name }}",
+        "api_base": "{{ .Values.models.iteration.apiBase }}"
+      }
+    }

--- a/openshift/pdf-to-podcast-chart/templates/frontend-deployment.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/frontend-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+        models-config-volume: shared
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: models-config-volume
+                operator: In
+                values:
+                - shared
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: frontend
+        image: "{{ .Values.imageRegistry }}/frontend:{{ .Values.frontend.image.tag }}"
+        imagePullPolicy: {{ include "pdf-to-podcast.imagePullPolicy" . }}
+        ports:
+        - containerPort: 7860
+          name: http
+        env:
+        - name: API_SERVICE_URL
+          value: "http://api-service:8002"
+        - name: DEFAULT_VOICE_2
+          value: "pFZP5JQG7iQjIQuC4Bku"
+        # Optional email configuration (if secrets provided)
+        {{- if .Values.emailConfig.enabled }}
+        - name: SENDER_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: SENDER_EMAIL
+        - name: SENDER_EMAIL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: SENDER_EMAIL_PASSWORD
+        {{- end }}
+        resources:
+          {{- toYaml .Values.frontend.resources | nindent 10 }}
+        livenessProbe:
+          tcpSocket:
+            port: 7860
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 7860
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        volumeMounts:
+        - name: models-storage
+          mountPath: /project
+        - name: demo-output
+          mountPath: /project/frontend/demo_outputs
+      volumes:
+      - name: models-storage
+        persistentVolumeClaim:
+          claimName: models-config
+      - name: demo-output
+        emptyDir: {}

--- a/openshift/pdf-to-podcast-chart/templates/models-pvc.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/models-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: models-config
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.modelsConfigPVC.size }}
+  {{- if .Values.modelsConfigPVC.storageClass }}
+  storageClassName: {{ .Values.modelsConfigPVC.storageClass }}
+  {{- end }}

--- a/openshift/pdf-to-podcast-chart/templates/namespace.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.global.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+{{- end }}

--- a/openshift/pdf-to-podcast-chart/templates/pdf-api-deployment.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/pdf-api-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pdf-api
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: pdf-api
+spec:
+  replicas: {{ .Values.pdfApi.replicas }}
+  selector:
+    matchLabels:
+      app: pdf-api
+  template:
+    metadata:
+      labels:
+        app: pdf-api
+        pdf-temp-volume: shared
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: pdf-temp-volume
+                operator: In
+                values:
+                - shared
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: pdf-api
+        image: "{{ .Values.imageRegistry }}/pdf-api:{{ .Values.pdfApi.image.tag }}"
+        imagePullPolicy: {{ include "pdf-to-podcast.imagePullPolicy" . }}
+        ports:
+        - containerPort: 8004
+          name: http
+        env:
+        - name: CELERY_BROKER_URL
+          value: "redis://{{ include "pdf-to-podcast.redisHost" . }}:6379/0"
+        - name: CELERY_RESULT_BACKEND
+          value: "redis://{{ include "pdf-to-podcast.redisHost" . }}:6379/0"
+        - name: REDIS_HOST
+          value: "{{ include "pdf-to-podcast.redisHost" . }}"
+        - name: REDIS_PORT
+          value: "6379"
+        - name: TEMP_FILE_DIR
+          value: "/tmp/pdf_conversions"
+        resources:
+          {{- toYaml .Values.pdfApi.resources | nindent 10 }}
+        volumeMounts:
+        - name: pdf-temp
+          mountPath: /tmp/pdf_conversions
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8004
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8004
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: pdf-temp
+        persistentVolumeClaim:
+          claimName: pdf-temp

--- a/openshift/pdf-to-podcast-chart/templates/pdf-service-deployment.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/pdf-service-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pdf-service
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: pdf-service
+spec:
+  replicas: {{ .Values.pdfService.replicas }}
+  selector:
+    matchLabels:
+      app: pdf-service
+  template:
+    metadata:
+      labels:
+        app: pdf-service
+    spec:
+      containers:
+      - name: pdf-service
+        image: "{{ .Values.imageRegistry }}/pdf-service:{{ .Values.pdfService.image.tag }}"
+        imagePullPolicy: {{ include "pdf-to-podcast.imagePullPolicy" . }}
+        ports:
+        - containerPort: 8003
+          name: http
+        env:
+        - name: OTLP_ENDPOINT
+          value: "{{ include "pdf-to-podcast.jaegerOtlpEndpoint" . }}"
+        - name: REDIS_URL
+          value: "redis://{{ include "pdf-to-podcast.redisHost" . }}:6379"
+        - name: MODEL_API_URL
+          value: "http://pdf-api:8004"
+        resources:
+          {{- toYaml .Values.pdfService.resources | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8003
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8003
+          initialDelaySeconds: 10
+          periodSeconds: 5

--- a/openshift/pdf-to-podcast-chart/templates/pvc.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/pvc.yaml
@@ -1,0 +1,19 @@
+# PDF temp storage shared between pdf-api and celery-worker
+# Redis and MinIO PVCs are managed by their respective subcharts
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pdf-temp
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: pdf-processing
+spec:
+  accessModes:
+    - {{ .Values.pdfTempStorage.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.pdfTempStorage.size }}
+  {{- if .Values.pdfTempStorage.storageClass }}
+  storageClassName: {{ .Values.pdfTempStorage.storageClass }}
+  {{- end }}

--- a/openshift/pdf-to-podcast-chart/templates/redis-deployment.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/redis-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: redis
+        image: "{{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+        imagePullPolicy: {{ include "pdf-to-podcast.imagePullPolicy" . }}
+        ports:
+        - containerPort: 6379
+          name: redis
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          {{- toYaml .Values.redis.resources | nindent 10 }}
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        livenessProbe:
+          tcpSocket:
+            port: 6379
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 6379
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: redis-data
+        emptyDir: {}

--- a/openshift/pdf-to-podcast-chart/templates/redis-service.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/redis-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: redis
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    protocol: TCP
+    name: redis
+  selector:
+    app: redis

--- a/openshift/pdf-to-podcast-chart/templates/routes.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/routes.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: pdf-to-podcast-api
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: api-service
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: api-service
+  port:
+    targetPort: http
+  {{- if .Values.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    {{- if .Values.route.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.frontendRoute.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: pdf-to-podcast-frontend
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: frontend
+spec:
+  {{- if .Values.frontendRoute.host }}
+  host: {{ .Values.frontendRoute.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: frontend
+  port:
+    targetPort: http
+  {{- if .Values.frontendRoute.tls.enabled }}
+  tls:
+    termination: {{ .Values.frontendRoute.tls.termination }}
+    {{- if .Values.frontendRoute.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.frontendRoute.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.jaegerRoute.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: jaeger-ui
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: jaeger
+spec:
+  {{- if .Values.jaegerRoute.host }}
+  host: {{ .Values.jaegerRoute.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ .Release.Name }}-jaeger-query
+  port:
+    targetPort: 16686
+  {{- if .Values.jaegerRoute.tls.enabled }}
+  tls:
+    termination: {{ .Values.jaegerRoute.tls.termination }}
+    {{- if .Values.jaegerRoute.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.jaegerRoute.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/openshift/pdf-to-podcast-chart/templates/secrets.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  NVIDIA_API_KEY: {{ .Values.apiKeys.nvidia | quote }}
+  ELEVENLABS_API_KEY: {{ .Values.apiKeys.elevenlabs | quote }}

--- a/openshift/pdf-to-podcast-chart/templates/services.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/services.yaml
@@ -1,0 +1,104 @@
+# Kubernetes Services for custom application services
+# Redis, MinIO, and Jaeger services are managed by their subcharts
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pdf-api
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: pdf-api
+spec:
+  ports:
+  - port: 8004
+    targetPort: 8004
+    name: http
+  selector:
+    app: pdf-api
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pdf-service
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: pdf-service
+spec:
+  ports:
+  - port: 8003
+    targetPort: 8003
+    name: http
+  selector:
+    app: pdf-service
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-service
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: agent-service
+spec:
+  ports:
+  - port: 8964
+    targetPort: 8964
+    name: http
+  selector:
+    app: agent-service
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tts-service
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: tts-service
+spec:
+  ports:
+  - port: 8889
+    targetPort: 8889
+    name: http
+  selector:
+    app: tts-service
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: api-service
+spec:
+  ports:
+  - port: 8002
+    targetPort: 8002
+    name: http
+  selector:
+    app: api-service
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: frontend
+spec:
+  ports:
+  - port: 7860
+    targetPort: 7860
+    name: http
+  selector:
+    app: frontend
+  type: ClusterIP

--- a/openshift/pdf-to-podcast-chart/templates/tts-service-deployment.yaml
+++ b/openshift/pdf-to-podcast-chart/templates/tts-service-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tts-service
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "pdf-to-podcast.labels" . | nindent 4 }}
+    app: tts-service
+spec:
+  replicas: {{ .Values.ttsService.replicas }}
+  selector:
+    matchLabels:
+      app: tts-service
+  template:
+    metadata:
+      labels:
+        app: tts-service
+    spec:
+      containers:
+      - name: tts-service
+        image: "{{ .Values.imageRegistry }}/tts-service:{{ .Values.ttsService.image.tag }}"
+        imagePullPolicy: {{ include "pdf-to-podcast.imagePullPolicy" . }}
+        ports:
+        - containerPort: 8889
+          name: http
+        env:
+        - name: OTLP_ENDPOINT
+          value: "{{ include "pdf-to-podcast.jaegerOtlpEndpoint" . }}"
+        - name: MAX_CONCURRENT_REQUESTS
+          value: "{{ .Values.maxConcurrentRequests }}"
+        - name: ELEVENLABS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: ELEVENLABS_API_KEY
+        - name: DEFAULT_VOICE_2
+          value: "pFZP5JQG7iQjIQuC4Bku"
+        - name: TTS_MODEL_ID
+          value: "eleven_flash_v2"
+        - name: REDIS_URL
+          value: "redis://{{ include "pdf-to-podcast.redisHost" . }}:6379"
+        resources:
+          {{- toYaml .Values.ttsService.resources | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8889
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8889
+          initialDelaySeconds: 10
+          periodSeconds: 5

--- a/openshift/pdf-to-podcast-chart/values-prod.yaml
+++ b/openshift/pdf-to-podcast-chart/values-prod.yaml
@@ -1,0 +1,56 @@
+# Production overrides
+
+# Higher replica counts for production
+apiService:
+  replicas: 3
+
+agentService:
+  replicas: 2
+
+ttsService:
+  replicas: 2
+
+pdfApi:
+  replicas: 2
+
+celeryWorker:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 4000m
+      memory: 8Gi
+    limits:
+      cpu: 8000m
+      memory: 16Gi
+
+frontend:
+  replicas: 1  # Single replica (demo/dev environment)
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+
+# Larger storage for production
+pdfTempStorage:
+  size: 20Gi
+
+minio:
+  volumeClaimTemplates:
+    - metadata:
+        name: minio-data
+      spec:
+        resources:
+          requests:
+            storage: 100Gi
+
+# Stronger MinIO credentials
+minio:
+  credentials:
+    rootUser: admin
+    # Generate password: openssl rand -base64 32
+    rootPassword: "CHANGE-ME-IN-PRODUCTION"
+
+maxConcurrentRequests: 5

--- a/openshift/pdf-to-podcast-chart/values.yaml
+++ b/openshift/pdf-to-podcast-chart/values.yaml
@@ -1,0 +1,270 @@
+# Default values for pdf-to-podcast
+# This is a YAML-formatted file.
+#
+# This chart follows OpenShift best practices by using Bitnami subcharts for
+# infrastructure (Redis, MinIO). This is the standard approach across certified
+# OpenShift partner charts. For long-term enterprise production, consider migrating
+# to Operators from OperatorHub while keeping this Helm chart for dev/test.
+
+# Global settings
+global:
+  namespace: pdf-to-podcast
+  createNamespace: false  # Set to true to create namespace, false to use existing
+  security:
+    # Allow using Quay.io registry (bypasses Bitnami's docker.io-only check)
+    allowInsecureImages: true
+
+# Image registry (OpenShift internal registry)
+imageRegistry: image-registry.openshift-image-registry.svc:5000/pdf-to-podcast
+
+# Image pull policy
+imagePullPolicy: Always
+
+# API Keys (passed via --set during deployment)
+apiKeys:
+  nvidia: ""  # Used for LLM (agent-service) - Set via --set or secrets
+  elevenlabs: ""  # Used for TTS service - Set via --set or secrets
+
+# Max concurrent TTS requests
+maxConcurrentRequests: 1
+
+# PDF temp storage (shared between pdf-api and celery-worker)
+pdfTempStorage:
+  size: 10Gi
+  storageClass: ""  # Use cluster default
+  accessMode: ReadWriteOnce  # Both pdf-api and celery-worker will be on same node
+
+#############################################################################
+# Redis configuration (standalone deployment using official Redis image)
+# Matches docker-compose setup: redis:latest with no persistence
+#############################################################################
+redis:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: redis
+    tag: latest
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+#############################################################################
+# MinIO configuration (using Red Hat AI Quickstart chart)
+# Docs: https://github.com/rh-ai-quickstart/ai-architecture-charts
+# Note: Application creates 'audio-results' bucket automatically on startup
+#############################################################################
+minio:
+  enabled: true
+  secret:
+    user: minioadmin
+    password: minioadmin  # CHANGE IN PRODUCTION
+    host: minio
+    port: "9000"
+  service:
+    type: ClusterIP
+    port: 9090  # Console UI
+    apiPort: 9000  # S3 API (what services connect to)
+  volumeClaimTemplates:
+    - metadata:
+        name: minio-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 50Gi
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+#############################################################################
+# Jaeger configuration (using official Jaeger chart v3.x)
+# Docs: https://github.com/jaegertracing/helm-charts
+#############################################################################
+jaeger:
+  enabled: true
+  provisionDataStore:
+    cassandra: false
+    elasticsearch: false
+  allInOne:
+    enabled: true
+    image:
+      registry: quay.io
+      repository: jaegertracing/all-in-one
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+    podSecurityContext:
+      runAsUser:
+      runAsGroup:
+      fsGroup:
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+  storage:
+    type: memory
+  agent:
+    enabled: false
+  collector:
+    enabled: false
+  query:
+    enabled: false
+
+# Celery Worker configuration
+celeryWorker:
+  image:
+    tag: "latest"
+  replicas: 1
+  gpu:
+    enabled: false  # Set to true for GPU acceleration
+    count: 1
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 8Gi
+    limits:
+      cpu: 2000m
+      memory: 10Gi
+
+# PDF API configuration
+pdfApi:
+  image:
+    tag: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+# PDF Service configuration
+pdfService:
+  image:
+    tag: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+# Agent Service configuration
+agentService:
+  image:
+    tag: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+# TTS Service configuration (NVIDIA Riva TTS)
+ttsService:
+  image:
+    tag: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+# API Service configuration
+apiService:
+  image:
+    tag: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+# OpenShift Route configuration
+route:
+  enabled: true
+  host: ""  # Auto-generated if empty
+  tls:
+    enabled: true
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
+#############################################################################
+# Frontend Service (Gradio web interface)
+#############################################################################
+frontend:
+  enabled: true
+  replicas: 1
+  image:
+    tag: latest
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+# Frontend Route (external access to Gradio UI)
+frontendRoute:
+  enabled: true
+  host: ""  # Auto-generated by OpenShift if not specified
+  tls:
+    enabled: true
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
+# Jaeger Route (external access to tracing UI - disable in production)
+jaegerRoute:
+  enabled: true
+  host: ""  # Auto-generated by OpenShift if not specified
+  tls:
+    enabled: true
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
+# Email configuration (optional)
+emailConfig:
+  enabled: false  # Set to true and provide secrets for email features
+
+# Models configuration PVC (writable storage for models.json config file)
+modelsConfigPVC:
+  size: 10Mi  # Small config file
+
+# Models configuration (from models.json)
+models:
+  reasoning:
+    name: "meta/llama-3.1-405b-instruct"
+    apiBase: "https://integrate.api.nvidia.com/v1"
+  json:
+    name: "meta/llama-3.1-70b-instruct"
+    apiBase: "https://integrate.api.nvidia.com/v1"
+  iteration:
+    name: "meta/llama-3.1-405b-instruct"
+    apiBase: "https://integrate.api.nvidia.com/v1"

--- a/openshift/secrets.env.template
+++ b/openshift/secrets.env.template
@@ -1,0 +1,14 @@
+# PDF-to-Podcast API Keys
+# Copy this file to secrets.env and fill in your actual keys
+# secrets.env is gitignored and will not be committed
+
+# NVIDIA API Key (used for LLM/agent-service)
+# Get from https://build.nvidia.com/
+NVIDIA_API_KEY=your-nvidia-api-key-here
+
+# ElevenLabs API Key (used for TTS service)
+# Get from https://elevenlabs.io/
+ELEVENLABS_API_KEY=your-elevenlabs-api-key-here
+
+# Optional: Max concurrent TTS requests (default: 1)
+MAX_CONCURRENT_REQUESTS=1

--- a/openshift/undeploy-helm.sh
+++ b/openshift/undeploy-helm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "🗑️  Uninstalling PDF-to-Podcast..."
+
+helm uninstall pdf-to-podcast -n pdf-to-podcast || true
+
+echo "🧹 Deleting namespace..."
+oc delete namespace pdf-to-podcast || true
+
+echo "✅ Cleanup complete!"

--- a/services/AgentService/podcast_flow.py
+++ b/services/AgentService/podcast_flow.py
@@ -199,7 +199,6 @@ async def podcast_generate_structured_outline(
         "enum": valid_filenames,
     }
 
-    schema = PodcastOutline.model_json_schema()
     template = PodcastPrompts.get_template(
         "podcast_multi_pdf_structured_outline_prompt"
     )

--- a/services/AgentService/podcast_prompts.py
+++ b/services/AgentService/podcast_prompts.py
@@ -91,7 +91,7 @@ Convert the following outline into a structured JSON format. The final section s
 Output Requirements:
 1. Each segment must include:
    - section name
-   - duration (in minutes) representing the length of the segment
+   - duration (in seconds) representing the length of the segment
    - list of references (file paths)
    - list of topics, where each topic has:
      - title
@@ -104,8 +104,8 @@ Output Requirements:
 3. Important notes:
    - References must be chosen from this list of valid filenames: {{ valid_filenames }}
    - References should only appear in the segment's "references" array, not as a topic
-   - Duration represents the length of each segment, not its starting timestamp
-   - Each segment's duration should be a positive number
+   - Duration represents the length of each segment in seconds, not its starting timestamp
+   - Each segment's duration MUST be a positive INTEGER in seconds (whole number only, no decimals)
 
 The result must conform to the following JSON schema:
 {{ schema }}

--- a/services/TTSService/main.py
+++ b/services/TTSService/main.py
@@ -23,6 +23,7 @@ MAX_CONCURRENT_REQUESTS = int(os.getenv("MAX_CONCURRENT_REQUESTS", "5"))
 DEFAULT_VOICE_1 = os.getenv("DEFAULT_VOICE_1", "iP95p4xoKVk53GoZ742B")
 DEFAULT_VOICE_2 = os.getenv("DEFAULT_VOICE_2", "9BWtsMINqrJLrRacOk9x")
 DEFAULT_VOICE_MAPPING = {"speaker-1": DEFAULT_VOICE_1, "speaker-2": DEFAULT_VOICE_2}
+TTS_MODEL_ID = os.getenv("TTS_MODEL_ID", "eleven_monolingual_v1")
 
 telemetry = OpenTelemetryInstrumentation()
 config = OpenTelemetryConfig(
@@ -191,7 +192,7 @@ class TTSService:
         audio_stream = self.eleven_labs_client.text_to_speech.convert(
             text=text,
             voice_id=voice_id,
-            model_id="eleven_monolingual_v1",
+            model_id=TTS_MODEL_ID,
             output_format="mp3_44100_128",
             voice_settings={"stability": 0.5, "similarity_boost": 0.75, "style": 0.0},
         )

--- a/shared/shared/podcast_types.py
+++ b/shared/shared/podcast_types.py
@@ -46,7 +46,7 @@ class Conversation(BaseModel):
         scratchpad (str): Working notes or context for the conversation
         dialogue (List[DialogueEntry]): List of dialogue entries making up the conversation
     """
-    scratchpad: str
+    scratchpad: str = ""
     dialogue: List[DialogueEntry]
 
 


### PR DESCRIPTION
## Add RHOAI deployment support with Helm

This PR adds complete RHOAI deployment support using Helm charts and BuildConfig-based image builds.

---

### What's Added

**Deployment Infrastructure:**
- Helm chart with Red Hat AI Quickstart (MinIO) and official Jaeger subcharts
- Custom Redis deployment templates
- BuildConfig automation for building container images directly in OpenShift cluster
- OpenShift Routes for external access to frontend, API, Jaeger, and MinIO
- Automated deployment scripts (`build-images.sh`, `deploy-helm.sh`, `undeploy-helm.sh`)

**Modified Notebook:**
- Updated `launchable/PDFtoPodcast.ipynb` with OpenShift flag support
- Added health check cells for service verification
- Adapted for RHOAI workbench environment with cluster-internal service URLs

**Documentation:**
- Comprehensive OpenShift deployment guide in `openshift/README.md`

---

### Features and Changes

- **One-command deployment:** `./build-images.sh all && ./deploy-helm.sh`
- **No external registry required:** Uses OpenShift internal registry for all images
- **Containerized frontend:** Added new Dockerfile for frontend service (`openshift/frontend/Dockerfile`)
- **Backward compatibility:** Modified `frontend/utils/email_demo.py`, `services/TTSService/main.py`, and notebook to support both OpenShift and local environments without breaking existing deployments

---

### Architecture

**Infrastructure (Subcharts):**
- MinIO (Red Hat AI Quickstart) - Object storage
- Jaeger (Official) - Distributed tracing  
- Redis (Custom templates) - Message broker and caching

**Application Services:**
Seven microservices deployed as Kubernetes Deployments with configurable resources and scaling.

---

Full deployment documentation and instructions available in `openshift/README.md`.