### PR TITLE
chore: align DEFAULT_CONFIGS fallback with models.json (nemotron-supe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more information about the PDF, Agent and TTS service flows, please refer to
    - Response generation (Inference)
       - [NIM for meta/llama-3.1-8b-instruct](https://build.nvidia.com/meta/llama-3_1-8b-instruct)
       - [NIM for meta/llama-3.1-70b-instruct](https://build.nvidia.com/meta/llama-3_1-70b-instruct)
-      - [NIM for meta/llama-3.1-405B-instruct](https://build.nvidia.com/meta/llama-3_1-405b-instruct)
+      - [NIM for nvidia/llama-3.3-nemotron-super-49b-v1.5](https://build.nvidia.com/nvidia/llama-3_3-nemotron-super-49b-v1_5)
 - Document ingest and extraction - [Docling](https://github.com/DS4SD/docling)
 - Text-to-speech - [ElevenLabs](https://elevenlabs.io/)
 - Redis - [Redis](https://redis.io/)

--- a/frontend/shared/shared/llmmanager.py
+++ b/frontend/shared/shared/llmmanager.py
@@ -57,11 +57,11 @@ class LLMManager:
 
     DEFAULT_CONFIGS = {
         "reasoning": {
-            "name": "meta/llama-3.1-405b-instruct",
+            "name": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
             "api_base": "https://integrate.api.nvidia.com/v1",
         },
         "iteration": {
-            "name": "meta/llama-3.1-405b-instruct",
+            "name": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
             "api_base": "https://integrate.api.nvidia.com/v1",
         },
         "json": {

--- a/shared/shared/llmmanager.py
+++ b/shared/shared/llmmanager.py
@@ -62,11 +62,11 @@ class LLMManager:
 
     DEFAULT_CONFIGS = {
         "reasoning": {
-            "name": "meta/llama-3.1-405b-instruct",
+            "name": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
             "api_base": "https://integrate.api.nvidia.com/v1",
         },
         "iteration": {
-            "name": "meta/llama-3.1-405b-instruct",
+            "name": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
             "api_base": "https://integrate.api.nvidia.com/v1",
         },
         "json": {

--- a/tests/test_invalid_filetype.py
+++ b/tests/test_invalid_filetype.py
@@ -36,7 +36,7 @@ def test(base_url: str):
         "duration": 5,
         "speaker_1_name": "Blackwell",
         "speaker_2_name": "Hopper",
-        "model": "meta/llama-3.1-405b-instruct",
+        "model": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
         "voice_mapping": voice_mapping,  # Add voice mapping
     }
 


### PR DESCRIPTION
…r-49b-v1.5)

Replaces the remaining `meta/llama-3.1-405b-instruct` references in code, test fixture, and README with `nvidia/llama-3.3-nemotron-super-49b-v1.5` to match the runtime config in models.json (set in commit e6a9255).

The runtime path (docker-compose -> MODEL_CONFIG_PATH=models.json) has been on Nemotron 49B for some time. This change brings the code-level fallback in LLMManager.DEFAULT_CONFIGS, the request-shape test fixture, and the README NIM-options bullet in line with that.

End-to-end smoke test: PDF -> outline -> 5 segments -> dialogue ->
combined transcript completed cleanly with Nemotron 49B for all reasoning + iteration calls (49 dialogue entries produced). Only TTS failed due to unrelated ElevenLabs quota_exceeded.

Out of scope: 70B json-role fallback (lines 73, 68), other Llama-3.1 references (8B local NIM image, frontend examples, notebook docs).